### PR TITLE
Fix the SKU in the Sailthru content synch script

### DIFF
--- a/sailthru/sailthru_content/services/sailthru_translation_service.py
+++ b/sailthru/sailthru_content/services/sailthru_translation_service.py
@@ -42,7 +42,7 @@ class SailthruTranslationService(object):
             'course_run': True,
             'marketing_url': url,
             'course_id': course['key'],
-            'course_run_id': course_run['key'],
+            'course_run_id': course_run['key']
         }
 
         for key in ['enrollment_end', 'enrollment_start', 'course_start', 'course_end']:
@@ -60,6 +60,7 @@ class SailthruTranslationService(object):
 
         # figure out the price(s) and save as Sailthru vars
         if course_run.get('seats'):
+            sailthru_content_vars['sku'] = self._return_sku(course_run.get('seats'))
             for seat in course_run['seats']:
                 sailthru_content_vars['price_{}'.format(seat['type'])] = seat['price']
                 sailthru_content_vars['currency_{}'.format(seat['type'])] = seat['currency']
@@ -138,10 +139,6 @@ class SailthruTranslationService(object):
 
         if len(tags) > 0:
             sailthru_content['tags'] = ", ".join(tags)
-
-        seats = course_run.get('seats')
-        if seats:
-            sailthru_content['sku'] = self._return_sku(seats)
 
         sailthru_content['vars'] = self._create_course_vars(
             course,

--- a/sailthru/sailthru_content/services/tests/catalog_api_test_mixins.py
+++ b/sailthru/sailthru_content/services/tests/catalog_api_test_mixins.py
@@ -6,8 +6,8 @@ from faker import Factory
 import responses
 
 
-from sailthru_content.services.catalog_api_service import CatalogApiService
-from sailthru_content.services.tests.fixtures import SINGLE_COURSE_DATA, SINGLE_PROGRAM_DATA
+from sailthru.sailthru_content.services.catalog_api_service import CatalogApiService
+from sailthru.sailthru_content.services.tests.fixtures import SINGLE_COURSE_DATA, SINGLE_PROGRAM_DATA
 
 
 class CatalogApiTestMixins(unittest.TestCase):

--- a/sailthru/sailthru_content/services/tests/fixtures.py
+++ b/sailthru/sailthru_content/services/tests/fixtures.py
@@ -77,7 +77,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": None,
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "abc"
                                 },
                                 {
                                     "type": u"verified",
@@ -85,7 +86,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": u"2017-03-10T23:58:00Z",
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "def"
                                 }
                             ],
                             "content_language": u"en-us",
@@ -185,7 +187,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": None,
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "ghi"
                                 },
                                 {
                                     "type": u"verified",
@@ -193,7 +196,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": u"2017-05-07T23:58:00Z",
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "jkl"
                                 }
                             ],
                             "content_language": u"en-us",
@@ -293,7 +297,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": None,
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "hf546h"
                                 },
                                 {
                                     "type": u"verified",
@@ -301,7 +306,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": u"2017-08-09T23:58:00Z",
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "hf7689h"
                                 }
                             ],
                             "content_language": u"en-us",
@@ -401,7 +407,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": None,
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "h4354fh"
                                 },
                                 {
                                     "type": u"verified",
@@ -409,7 +416,8 @@ SINGLE_PROGRAM_DATA = {
                                     "currency": u"USD",
                                     "upgrade_deadline": u"2017-11-05T23:58:00Z",
                                     "credit_provider": None,
-                                    "credit_hours": None
+                                    "credit_hours": None,
+                                    "sku": "u323"
                                 }
                             ],
                             "content_language": u"en-us",
@@ -709,7 +717,8 @@ SINGLE_COURSE_DATA = {
                             "currency": u"USD",
                             "upgrade_deadline": None,
                             "credit_provider": None,
-                            "credit_hours": None
+                            "credit_hours": None,
+                            "sku": "hfh"
                         },
                         {
                             "type": u"verified",
@@ -718,7 +727,8 @@ SINGLE_COURSE_DATA = {
                             'sku': u"sku001",
                             "upgrade_deadline": None,
                             "credit_provider": None,
-                            "credit_hours": None
+                            "credit_hours": None,
+                            "sku": "ghie"
                         }
                     ],
                     "content_language": u"en-us",

--- a/sailthru/sailthru_content/services/tests/test_catalog_api_service.py
+++ b/sailthru/sailthru_content/services/tests/test_catalog_api_service.py
@@ -1,7 +1,7 @@
 import responses
 
-from services.tests.catalog_api_test_mixins import CatalogApiTestMixins
-from services.tests.fixtures import SINGLE_COURSE_DATA, SINGLE_PROGRAM_DATA
+from sailthru.sailthru_content.services.tests.catalog_api_test_mixins import CatalogApiTestMixins
+from sailthru.sailthru_content.services.tests.fixtures import SINGLE_COURSE_DATA, SINGLE_PROGRAM_DATA
 
 
 class CatalogApiServiceTests(CatalogApiTestMixins):

--- a/sailthru/sailthru_content/services/tests/test_sailthru_api_service.py
+++ b/sailthru/sailthru_content/services/tests/test_sailthru_api_service.py
@@ -3,7 +3,7 @@ import unittest
 
 from faker import Factory
 
-from services.sailthru_api_service import SailthruApiService
+from sailthru.sailthru_content.services.sailthru_api_service import SailthruApiService
 
 
 class SailthruApiServiceTests(unittest.TestCase):

--- a/sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
+++ b/sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
@@ -4,9 +4,9 @@ from faker import Factory
 import ddt
 import responses
 
-from sailthru_content.services.sailthru_translation_service import SailthruTranslationService
-from sailthru_content.services.tests.catalog_api_test_mixins import CatalogApiTestMixins
-from sailthru_content.services.tests.fixtures import SINGLE_COURSE_DATA
+from sailthru.sailthru_content.services.sailthru_translation_service import SailthruTranslationService
+from sailthru.sailthru_content.services.tests.catalog_api_test_mixins import CatalogApiTestMixins
+from sailthru.sailthru_content.services.tests.fixtures import SINGLE_COURSE_DATA
 
 
 @ddt.ddt
@@ -30,7 +30,6 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
         expected_sailthru_item = {
             'site_name': 'HamiltonX',
             'description': '.',
-            'sku': {'verified': 'sku001'},
             'vars': {
                 'price_audit': '0.00',
                 'site_name': 'HamiltonX',
@@ -44,7 +43,8 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
                 'price_verified': '49.00',
                 'course_start': '2016-10-18',
                 'marketing_url': 'https://www.edx.org/course/ethics-sports-do-sports-morally-matter-hamiltonx-phil108x?utm_source=simonthebestedx&utm_medium=affiliate_partner',
-                'course_type': 'audit'
+                'course_type': 'audit',
+                'sku': {'verified': 'ghie'}
             },
             'title': 'Ethics of Sports: Do Sports Morally Matter?',
             'url': '{root}/courses/{key}/info'.format(
@@ -105,7 +105,7 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
         }
 
         if seat_type in ['professional', 'verified']:
-            expected_sailthru_item.update({
+            expected_sailthru_item['vars'].update({
                 'sku': {seat_type: 'sku001'}
             })
 


### PR DESCRIPTION
ECOM-4413
@clintonb @tasawernawaz Please review
This is to fix the problem where SKU do not show in Sailthru. 
@tasawernawaz The reason SKU do not show is because the data is not within the `vars` property. The "SKU" was on the same level as a course object. But according to Sailthru documentation, they do not accept custom property key unless they are in the `vars` dictionary.

I also run some unit tests to ensure they are working. That's why you see the changes in Unit tests files