### PR TITLE
Allow the script to be run without invoking the interpreter

### DIFF
--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 This script can be used to automatically pull translations from Transifex,
 commit, push, and merge them to their respective repos.


### PR DESCRIPTION
Also make it more clear that the script requires Python 3.