### PR TITLE
Compile updated messages

### DIFF
--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -1,3 +1,4 @@
+Django==1.9.12
 PyGithub==1.29
 PyYAML==3.12
 transifex-client==0.12.2


### PR DESCRIPTION
When .po files are updated, they need to be compiled to .mo files for use with gettext. This is a project-agnostic approach for accomplishing that.

@edx/ecommerce FYI. This will prevent issues like the one detailed at https://github.com/edx/course-discovery/pull/499#issuecomment-269513662, and has already been run against programs (https://github.com/edx/programs/pull/190).