### PR TITLE
Avoid merging PRs if message compilation fails

### DIFF
--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -232,6 +232,10 @@ def pull(repo):
                     )
                 )
 
+                # Return immediately, without trying to merge the PR. We don't
+                # want to merge PRs without compiled messages.
+                return
+
             retries = 0
             while retries <= MAX_RETRIES:
                 try:


### PR DESCRIPTION
It's not safe to assume that a repo's Travis build will check message compilation. If we know message compilation is failing, we shouldn't attempt to merge.

@andy-armstrong FYI. This is in response to https://github.com/edx/edx-proctoring/pull/331.