### PR TITLE
Update the sailthru synch script to use a smaller batch size for catalog api query

### DIFF
--- a/edx_sailthru/sailthru_content/services/catalog_api_service.py
+++ b/edx_sailthru/sailthru_content/services/catalog_api_service.py
@@ -4,7 +4,7 @@ from edx_rest_api_client.client import EdxRestApiClient
 
 
 logger = logging.getLogger()
-COURSES_PAGE_SIZE = 500
+COURSES_PAGE_SIZE = 100
 PROGRAMS_PAGE_SIZE = 40
 
 


### PR DESCRIPTION
@rlucioni @MatthewPiatetsky Please help review

Just decrease the catalog query batch size from 500 to 100.
This certainly makes the Sailthru synch script run last longer, but that's intended