### PR TITLE
Add support for custom merge methods to translation scripts

### DIFF
--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -49,13 +49,7 @@ def pull(repo, skip_compilemessages=False):
             else:
                 compilemessages_succeeded = repo.compilemessages()
 
-            if repo.is_changed():
-                logger.info('Translations have changed for [%s]. Pushing them to GitHub and opening a PR.', repo.name)
-                repo.commit()
-                repo.push()
-                pr = repo.pr()
-            else:
-                logger.info('No changes detected for [%s]. Cleaning up.', repo.name)
+            pr = repo.commit_push_and_open_pr()
 
         if pr:
             if not (skip_compilemessages or compilemessages_succeeded):

--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -34,7 +34,6 @@ def pull(repo, skip_compilemessages=False):
     If applicable, commits them, pushes them to GitHub, opens a PR, waits for
     status checks to pass, then merges the PR and deletes the branch.
     """
-    pr = None
     logger.info('Pulling translations for [%s].', repo.name)
 
     try:
@@ -49,12 +48,13 @@ def pull(repo, skip_compilemessages=False):
             else:
                 compilemessages_succeeded = repo.compilemessages()
 
-            pr = repo.commit_push_and_open_pr()
+            repo.commit_push_and_open_pr()
 
-        if pr:
+        if repo.pr:
             if not (skip_compilemessages or compilemessages_succeeded):
+
                 # Notify the team that message compilation failed.
-                pr.create_issue_comment(
+                repo.pr.create_issue_comment(
                     '@{owner} failing message compilation prevents this PR from being automatically merged. '
                     'Refer to the build log for more details.'.format(
                         owner=repo.owner
@@ -65,10 +65,10 @@ def pull(repo, skip_compilemessages=False):
                 # want to merge PRs without compiled messages.
                 return
 
-            repo.merge_pr(pr)
+            repo.merge_pr()
 
     finally:
-        repo.cleanup(pr)
+        repo.cleanup()
 
 
 def parse_arguments():

--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -19,37 +19,20 @@ If you want to skip the compile messages step, pass the --skip-compilemessages o
 
     python transifex/pull.py git@github.com:edx/course-discovery.git --skip-compilemessages
 """
-import os
 import time
 from argparse import ArgumentParser
-from contextlib import contextmanager
 from os.path import abspath, dirname, join
 
 import yaml
 from github import GithubException
 
 import concurrent.futures
-from utils.common import Repo, logger
+from utils.common import Repo, cd, logger
 
 # Combined with exponential backoff, limiting retries to 10 results in
 # a total 34 minutes of sleep time. Status checks should almost always
 # complete in this period.
 MAX_RETRIES = 10
-
-
-@contextmanager
-def cd(repo):
-    """Utility for changing into and out of a repo."""
-    initial_directory = os.getcwd()
-    os.chdir(repo.name)
-
-    # Exception handler ensures that we always change back to the
-    # initial directory, regardless of how control is returned
-    # (e.g., an exception is raised while changed into the new directory).
-    try:
-        yield
-    finally:
-        os.chdir(initial_directory)
 
 
 def pull(repo):

--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -19,7 +19,6 @@ If you want to skip the compile messages step, pass the --skip-compilemessages o
 
     python transifex/pull.py git@github.com:edx/course-discovery.git --skip-compilemessages
 """
-import logging
 import os
 import re
 import subprocess
@@ -27,7 +26,6 @@ import sys
 import time
 from argparse import ArgumentParser
 from contextlib import contextmanager
-from logging.config import dictConfig
 from os.path import abspath, dirname, join
 from urllib.parse import urlparse
 
@@ -36,31 +34,8 @@ import yaml
 import concurrent.futures
 from github import Github, GithubException
 
-# Configure logging.
-dictConfig({
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'standard': {
-            'format': '%(asctime)s %(levelname)s %(process)d [%(filename)s:%(lineno)d] - %(message)s',
-        },
-    },
-    'handlers': {
-        'console': {
-            'level': 'INFO',
-            'class': 'logging.StreamHandler',
-            'formatter': 'standard',
-        },
-    },
-    'loggers': {
-        '': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False
-        },
-    },
-})
-logger = logging.getLogger()
+from utils.common import logger
+
 
 # Combined with exponential backoff, limiting retries to 10 results in
 # a total 34 minutes of sleep time. Status checks should almost always

--- a/transifex/utils/common.py
+++ b/transifex/utils/common.py
@@ -129,6 +129,19 @@ class Repo:
         except subprocess.CalledProcessError:
             return False
 
+    def commit_push_and_open_pr(self):
+        """Convenience method that will detect changes that have been made to the repo, commit them, push them
+           to Github, and open a PR.
+        """
+        if self.is_changed():
+            logger.info('Changes detected for [%s]. Pushing them to GitHub and opening a PR.', self.name)
+            self.commit()
+            self.push()
+            return self.pr()
+        else:
+            logger.info('No changes detected for [%s].', repo.name)
+            return
+
     def is_changed(self):
         """Determine whether any changes were made."""
         completed_process = subprocess.run(['git', 'status', '--porcelain'], stdout=subprocess.PIPE, check=True)

--- a/transifex/utils/common.py
+++ b/transifex/utils/common.py
@@ -1,6 +1,12 @@
 import logging
+import os
+import re
+import subprocess
 from logging.config import dictConfig
+from urllib.parse import urlparse
 
+import yaml
+from github import Github
 
 # Configure logging.
 dictConfig({
@@ -27,3 +33,129 @@ dictConfig({
     },
 })
 logger = logging.getLogger()
+
+
+# Initialize GitHub client. For documentation,
+# see http://pygithub.github.io/PyGithub/v1/reference.html.
+github_access_token = os.environ['GITHUB_ACCESS_TOKEN']
+github = Github(github_access_token)
+edx = github.get_organization('edx')
+
+
+class Repo:
+    """Utility representing a Git repo."""
+    def __init__(self, clone_url, skip_compilemessages=False):
+        # See https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth.
+        parsed = urlparse(clone_url)
+        self.clone_url = '{scheme}://{token}@{netloc}{path}'.format(
+            scheme=parsed.scheme,
+            token=github_access_token,
+            netloc=parsed.netloc,
+            path=parsed.path
+        )
+
+        match = re.match(r'.*edx/(?P<name>.*).git', self.clone_url)
+        self.name = match.group('name')
+
+        self.github_repo = edx.get_repo(self.name)
+        self.owner = None
+        self.branch_name = 'update-translations'
+        self.message = 'Update translations'
+        self.skip_compilemessages = skip_compilemessages
+        self.compilemessages_failed = False
+
+    def clone(self):
+        """Clone the repo."""
+        subprocess.run(['git', 'clone', '--depth', '1', self.clone_url], check=True)
+
+        # Assumes the existence of repo metadata YAML, standardized in
+        # https://open-edx-proposals.readthedocs.io/en/latest/oep-0002.html.
+        with open('{}/openedx.yaml'.format(self.name)) as f:
+            repo_metadata = yaml.load(f)
+            self.owner = repo_metadata['owner']
+
+    def branch(self):
+        """Create and check out a new branch."""
+        subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
+
+    def update_translations(self):
+        """Download and compile messages from Transifex.
+
+        Assumes this repo defines the `pull_translations` Make target and a
+        project config file at .tx/config. Running the Transifex client also
+        requires specifying Transifex credentials at ~/.transifexrc.
+
+        See http://docs.transifex.com/client/config/.
+        """
+        subprocess.run(['make', 'pull_translations'], check=True)
+
+        if self.skip_compilemessages:
+            logger.info('Skipping compilemessages.')
+            return
+
+        # Messages may fail to compile (e.g., a translator may accidentally translate a
+        # variable in a Python format string). If this happens, we want to proceed with
+        # the PR process and notify the team that messages failed to compile.
+        try:
+            # The compilemessages command is a script that (as of Django 1.9) scans the project
+            # tree for .po files to compile and calls GNU gettext's msgfmt command on them. It
+            # doesn't require DJANGO_SETTINGS_MODULE to be defined when run from the project root,
+            # and also doesn't need django.setup() to be run. Because of this, we can get away with
+            # django-admin.py instead of manage.py. The latter defines a default value for
+            # DJANGO_SETTINGS_MODULE and causes django.setup() to run, which is undesirable here for reasons
+            # ranging from Python 2/3 incompatibility errors across projects to forcing the installation
+            # of packages which provide installed apps custom to each project.
+            subprocess.run(['django-admin.py', 'compilemessages'], check=True)
+        except subprocess.CalledProcessError:
+            self.compilemessages_failed = True
+
+    def is_changed(self):
+        """Determine whether any changes were made."""
+        completed_process = subprocess.run(['git', 'status', '--porcelain'], stdout=subprocess.PIPE, check=True)
+        return bool(completed_process.stdout)
+
+    def commit(self):
+        """Commit changes.
+
+        Adds any untracked files, in case new translations are added.
+        """
+        subprocess.run(['git', 'add', '-A'], check=True)
+        try:
+            subprocess.run(['git', 'commit', '-m', self.message], check=True)
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                [
+                    'git',
+                    '-c', 'user.name="{}"'.format(os.environ['GIT_USER_NAME']),
+                    '-c', 'user.email={}'.format(os.environ['GIT_USER_EMAIL']),
+                    'commit', '-m', self.message
+                ],
+                check=True
+            )
+
+    def push(self):
+        """Push branch to the remote."""
+        subprocess.run(['git', 'push', '-u', 'origin', self.branch_name], check=True)
+
+    def pr(self):
+        """Create a new PR on GitHub."""
+        return self.github_repo.create_pull(
+            self.message,
+            'This PR was created by a script.',
+            'master',
+            self.branch_name
+        )
+
+    def cleanup(self, pr):
+        """Delete the local clone of the repo.
+
+        If applicable, also deletes the merged branch from GitHub.
+        """
+        if pr and pr.is_merged():
+            logger.info('Deleting merged branch %s:%s.', self.name, self.branch_name)
+            # Delete branch from remote. See https://developer.github.com/v3/git/refs/#get-a-reference.
+            ref = 'heads/{branch}'.format(branch=self.branch_name)
+            self.github_repo.get_git_ref(ref).delete()
+
+        # Delete cloned repo.
+        subprocess.run(['rm', '-rf', self.name], check=True)

--- a/transifex/utils/common.py
+++ b/transifex/utils/common.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import subprocess
+from contextlib import contextmanager
 from logging.config import dictConfig
 from urllib.parse import urlparse
 
@@ -33,6 +34,21 @@ dictConfig({
     },
 })
 logger = logging.getLogger()
+
+
+@contextmanager
+def cd(repo):
+    """Utility for changing into and out of a repo."""
+    initial_directory = os.getcwd()
+    os.chdir(repo.name)
+
+    # Exception handler ensures that we always change back to the
+    # initial directory, regardless of how control is returned
+    # (e.g., an exception is raised while changed into the new directory).
+    try:
+        yield
+    finally:
+        os.chdir(initial_directory)
 
 
 # Initialize GitHub client. For documentation,

--- a/transifex/utils/common.py
+++ b/transifex/utils/common.py
@@ -52,6 +52,21 @@ def cd(repo):
         os.chdir(initial_directory)
 
 
+@contextmanager
+def repo_context(*args, **kwargs):
+    """Utility for cloning a repo, cd'ing to it, creating a working branch, doing some work, and then cleaning
+       everything up.
+    """
+    repo = Repo(*args, **kwargs)
+    try:
+        repo.clone()
+        with cd(repo):
+            repo.branch()
+            yield repo
+    finally:
+        repo.cleanup()
+
+
 # Initialize GitHub client. For documentation,
 # see http://pygithub.github.io/PyGithub/v1/reference.html.
 github_access_token = os.environ['GITHUB_ACCESS_TOKEN']

--- a/transifex/utils/common.py
+++ b/transifex/utils/common.py
@@ -1,0 +1,29 @@
+import logging
+from logging.config import dictConfig
+
+
+# Configure logging.
+dictConfig({
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'standard': {
+            'format': '%(asctime)s %(levelname)s %(process)d [%(filename)s:%(lineno)d] - %(message)s',
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'standard',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False
+        },
+    },
+})
+logger = logging.getLogger()


### PR DESCRIPTION
These changes enable us to use a custom merge method when merging PRs produced via the translation scripts. This is necessary since several of our repositories (credentials, course-discovery, ecommerce, edx-mktg) do not allow merge commits.

Depends on https://github.com/edx/ecommerce-scripts/pull/55

JIRA: https://openedx.atlassian.net/browse/LEARNER-1089 

Note: it should only be necessary to review https://github.com/edx/ecommerce-scripts/pull/56/commits/1f805f88857823d2ec23c298205a918125384ecd as all the other commits are from https://github.com/edx/ecommerce-scripts/pull/55