### PR TITLE
Update transifex dependencies

### DIFF
--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.9.12
+Django==1.11.2
 PyGithub==1.29
 PyYAML==3.12
-transifex-client==0.12.2
+transifex-client==0.12.4


### PR DESCRIPTION
This is necessary in order to support running the marketing site's extract_translations scripts, which does not work with django 1.9. 

Currently, the transifex/pull script only uses django to run the compilemessages command. I tested this command using django 1.11.2 with each of the repositories with which we use transifex/pull, and found no issues.

JIRA: https://openedx.atlassian.net/browse/LEARNER-1422