### PR TITLE
Added course_run and program tags for data sent to Sailthru

### DIFF
--- a/edx_sailthru/requirements/base.txt
+++ b/edx_sailthru/requirements/base.txt
@@ -1,3 +1,2 @@
-nose==1.3.7
-edx-rest-api-client==1.6.0
-sailthru-client==2.2.3
+edx-rest-api-client==1.7.1
+sailthru-client==2.3.1

--- a/edx_sailthru/requirements/base.txt
+++ b/edx_sailthru/requirements/base.txt
@@ -1,2 +1,3 @@
 edx-rest-api-client==1.7.1
+python-slugify==1.2.4
 sailthru-client==2.3.1

--- a/edx_sailthru/requirements/test.txt
+++ b/edx_sailthru/requirements/test.txt
@@ -1,10 +1,9 @@
 # Packages required for testing
 -r base.txt
 
-ddt==1.0.0
-factory_boy==2.7.0
-pytest==3.0.5
-responses==0.5.1
-Faker==0.7.3
+ddt==1.1.1
+factory_boy==2.8.1
+Faker==0.7.17
 mock==2.0.0
-
+pytest==3.1.2
+responses==0.5.1

--- a/edx_sailthru/sailthru_content/services/catalog_api_service.py
+++ b/edx_sailthru/sailthru_content/services/catalog_api_service.py
@@ -16,10 +16,9 @@ class CatalogApiService(object):
         if not access_token:
             logger.info('No access token provided. Retrieving access token using client_credential flow...')
             try:
-                self.access_token, expires = EdxRestApiClient.get_oauth_access_token(
-                    '{root}/access_token'.format(root=oauth_host),
-                    oauth_key,
-                    oauth_secret, token_type='jwt'
+                access_token_url = '{}/access_token'.format(oauth_host)
+                self.access_token, __ = EdxRestApiClient.get_oauth_access_token(
+                    access_token_url, oauth_key, oauth_secret, token_type='jwt'
                 )
             except Exception:
                 logger.exception('No access token provided or acquired through client_credential flow.')

--- a/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
+++ b/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
@@ -77,7 +77,7 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
             'site_name': 'HamiltonX',
             'description': '.',
             'vars': {
-                'sku': {u'verified': u'ghie'},
+                'sku': {'verified': 'ghie'},
                 'price_audit': '0.00',
                 'site_name': 'HamiltonX',
                 'course_run': True,

--- a/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
+++ b/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
@@ -53,7 +53,7 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
                 root=self.lms_root,
                 key=SINGLE_COURSE_DATA['results'][0]['course_runs'][0]['key']
             ),
-            'tags': 'subject-Education-Teacher-Training, subject-Philosophy-Ethics, subject-Health-Safety, school-HamiltonX',
+            'tags': 'course-run,subject-Education-Teacher-Training,subject-Philosophy-Ethics,subject-Health-Safety,school-HamiltonX',
             'spider': 0,
             'images': {
                 'thumb': {
@@ -69,8 +69,14 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
         self.prepare_get_courses()
         self.prepare_get_programs()
         translated_programs = self.sailthru_translation_service.translate_programs()
-        self.assertEqual(len(translated_programs), 1)
-        self.assertEqual(len(translated_programs[0]['vars']['course_runs']), 4)
+        assert len(translated_programs) == 1
+
+        program = translated_programs[0]
+        assert len(program['vars']['course_runs']) == 4
+
+        tags = program['tags'].split(',')
+        assert 'program' in tags
+        assert 'program-micromasters' in tags
 
     def _get_expected_sailthru_item(self, seat_type=None):
         expected_sailthru_item = {
@@ -98,7 +104,7 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
                 root=self.lms_root,
                 key=SINGLE_COURSE_DATA['results'][0]['course_runs'][0]['key']
             ),
-            'tags': 'subject-Education-Teacher-Training, subject-Philosophy-Ethics, subject-Health-Safety, school-HamiltonX',
+            'tags': 'course-run,subject-Education-Teacher-Training,subject-Philosophy-Ethics,subject-Health-Safety,school-HamiltonX',
             'spider': 0,
             'images': {
                 'thumb': {


### PR DESCRIPTION
- All course runs now include the course_run tag 
- Programs now include a program tag and a tag with the slugified program type (e.g. program-micromasters)