### PR TITLE
Modify 'site_name' string to include all course owners

### DIFF
--- a/edx_sailthru/sailthru_content/services/sailthru_translation_service.py
+++ b/edx_sailthru/sailthru_content/services/sailthru_translation_service.py
@@ -110,6 +110,13 @@ class SailthruTranslationService(object):
         """ Return dict of sku for a course run. """
         return {seat['type']: seat['sku'] for seat in seats if seat['type'] in REQUIRED_SEATS_TYPES}
 
+    def get_course_owners(self, course):
+        owners = []
+        for owner in course.get('owners'):
+            #replace underscore in the owner's name if any
+            owners.append(owner['key'].replace('_', ' '))
+        return ' '.join(owners)
+
     def translate_course_run(self, course_run, course, program_dictionary=None):
         # get marketing url
         url = course_run.get('marketing_url', course.get('marketing_url'))
@@ -124,9 +131,9 @@ class SailthruTranslationService(object):
         if course_run.get('short_description'):
             sailthru_content['description'] = course_run.get('short_description')
 
-        # get first owner
+        # get owners
         if course.get('owners') and len(course.get('owners')) > 0:
-            sailthru_content['site_name'] = course['owners'][0]['key'].replace('_', ' ')
+            sailthru_content['site_name'] = self.get_course_owners(course)
 
         # use enrollment_end for sailthru expire_date
         if course_run.get('enrollment_end'):

--- a/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
+++ b/edx_sailthru/sailthru_content/services/tests/test_sailthru_translation_service.py
@@ -133,3 +133,18 @@ class SailthruTranslationServiceTests(CatalogApiTestMixins):
         self.assertEqual(len(translated_course_runs), 1)
         self.assertDictEqual(translated_course_runs[0], self._get_expected_sailthru_item(seat_type))
         self.remove_seat(seat_type)
+
+    @responses.activate
+    def test_verify_multiple_owners(self):
+        course = {
+            "owners": [
+                {
+                "key": "Adelaide_X"
+                },
+                {
+                "key": "ACCA"
+                }
+            ]
+        }
+        owners = SailthruTranslationService.get_course_owners(self, course)
+        self.assertEqual("Adelaide X ACCA", owners)


### PR DESCRIPTION
## [LEARNER-2109](https://openedx.atlassian.net/browse/LEARNER-2109)
### Description
Modify 'site_name' string to include all course owners

'site_name' in the 'course_weekly' data feeds on sailthru contains
only one course owner.In order to give credit to all organisations
of a given course there is a need to update 'site_name' in a way
that it will contain all the course owners.

### Testing
- [x] Unit