### PR TITLE
LEARNER-2653 Modified transifex.push for edx-platform push job

### DIFF
--- a/transifex/push.py
+++ b/transifex/push.py
@@ -32,9 +32,14 @@ def push(clone_url, merge_method=DEFAULT_MERGE_METHOD):
     with repo_context(clone_url, BRANCH_NAME, MESSAGE, merge_method=merge_method) as repo:
         logger.info('Extracting translations for [%s].', repo.name)
         repo.extract_translations()
-        repo.commit_push_and_open_pr()
 
-        if repo.pr and repo.merge_pr() and repo.pr.is_merged():
+        if repo.is_changed():
+            repo.commit_push_and_open_pr()
+
+            if repo.pr and repo.merge_pr() and repo.pr.is_merged():
+                logger.info('Pushing translations to Transifex for [%s].', repo.name)
+                repo.push_translations()
+        else:
             logger.info('Pushing translations to Transifex for [%s].', repo.name)
             repo.push_translations()
 


### PR DESCRIPTION
**[LEARNER-2653](https://openedx.atlassian.net/browse/LEARNER-2653)**

**Description :** 
This pr is part of the process to automate edx-platform translations process. As the edx-platform does not create any code changes and translations are later merged when pulled. This code would have failed for edx-platform. i have updated it such that it follows pull request process if there are code changes if there are not any code changes it will simply push the translations to transifex. Now this will work for edx-platform job too. Where push does not request any pull request. 
Al though now it will send the same files to transifex in case of mktg and edx-platform once every day even if there was no change. 