### PR TITLE
Argumrnt added to remove git process for edx-platform

### DIFF
--- a/transifex/push.py
+++ b/transifex/push.py
@@ -25,7 +25,7 @@ BRANCH_NAME = 'update-translation-strings'
 MESSAGE = 'Update translation strings'
 
 
-def push(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, no_commit=False):
+def push(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, skip_commit=False):
     """Extracts translations for the given repo, commits them, pushes them to GitHub, opens a PR, waits for status
         checks to pass, merges the PR, deletes the branch, and pushes the updated translation files to Transifex.
     """
@@ -33,7 +33,7 @@ def push(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, no_commit=Fal
         logger.info('Extracting translations for [%s].', repo.name)
         repo.extract_translations()
 
-        if not no_commit:
+        if not skip_commit:
             repo.commit_push_and_open_pr()
             if repo.pr and repo.merge_pr() and repo.pr.is_merged():
                 push_translations_to_transifex(repo)
@@ -45,7 +45,6 @@ def push_translations_to_transifex(repo):
     """
     Calls the push translations make target to push new translation strings to Transifex.
     """
-    logger.info('Pushing translations to Transifex for [%s].', repo.name)
     repo.push_translations()
 
 
@@ -66,7 +65,7 @@ def parse_arguments():
         help='Method to use when merging the PR. See https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button for details.'
     )
     parser.add_argument(
-        '--no-commit',
+        '--skip_commit',
         action='store_true',
         help='Use this if you do not want to commit changes to repo.'
     )
@@ -75,4 +74,4 @@ def parse_arguments():
 
 if __name__ == '__main__':
     args = parse_arguments()
-    push(args.clone_url, args.repo_owner, merge_method=args.merge_method, no_commit=args.no_commit)
+    push(args.clone_url, args.repo_owner, merge_method=args.merge_method, skip_commit=args.skip_commit)

--- a/transifex/push.py
+++ b/transifex/push.py
@@ -25,18 +25,28 @@ BRANCH_NAME = 'update-translation-strings'
 MESSAGE = 'Update translation strings'
 
 
-def push(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD):
+def push(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, no_commit=False):
     """Extracts translations for the given repo, commits them, pushes them to GitHub, opens a PR, waits for status
         checks to pass, merges the PR, deletes the branch, and pushes the updated translation files to Transifex.
     """
     with repo_context(clone_url, repo_owner, BRANCH_NAME, MESSAGE, merge_method=merge_method) as repo:
         logger.info('Extracting translations for [%s].', repo.name)
         repo.extract_translations()
-        repo.commit_push_and_open_pr()
 
-        if repo.pr and repo.merge_pr() and repo.pr.is_merged():
-            logger.info('Pushing translations to Transifex for [%s].', repo.name)
-            repo.push_translations()
+        if not no_commit:
+            repo.commit_push_and_open_pr()
+            if repo.pr and repo.merge_pr() and repo.pr.is_merged():
+                push_translations_to_transifex(repo)
+        else:
+            push_translations_to_transifex(repo)
+
+
+def push_translations_to_transifex(repo):
+    """
+    Calls the push translations make target to push new translation strings to Transifex.
+    """
+    logger.info('Pushing translations to Transifex for [%s].', repo.name)
+    repo.push_translations()
 
 
 def parse_arguments():
@@ -55,9 +65,14 @@ def parse_arguments():
         default=DEFAULT_MERGE_METHOD,
         help='Method to use when merging the PR. See https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button for details.'
     )
+    parser.add_argument(
+        '--no-commit',
+        action='store_true',
+        help='Use this if you do not want to commit changes to repo.'
+    )
     return parser.parse_args()
 
 
 if __name__ == '__main__':
     args = parse_arguments()
-    push(args.clone_url, args.repo_owner, merge_method=args.merge_method)
+    push(args.clone_url, args.repo_owner, merge_method=args.merge_method, no_commit=args.no_commit)

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -193,6 +193,7 @@ class Repo:
 
         See http://docs.transifex.com/client/config/.
         """
+        logger.info('Pushing translations to Transifex for [%s].', self.name)
         subprocess.run(['make', 'push_translations'], check=True)
 
     def commit_push_and_open_pr(self):


### PR DESCRIPTION
As the make extract creates a lot of changes for edx-platform this will prevent push translations job to push those translations to edx-platform repo. 