### PR TITLE
LEARNER-4195 Make sure jenkins automated jobs fail when error during the job

### DIFF
--- a/edx_sailthru/sailthru_content/services/sailthru_api_service.py
+++ b/edx_sailthru/sailthru_content/services/sailthru_api_service.py
@@ -23,6 +23,7 @@ class SailthruApiService(object):
                 response.json['error'],
                 response.json['errormsg']
             )
+            raise RuntimeError('Failed to connect with Sailthru API')
         else:
             for body in response.json['content']:
                 logging.info(body)
@@ -57,6 +58,7 @@ class SailthruApiService(object):
             logging.error("Error: " + error.get_message())
             logging.error("Status Code: " + str(response.get_status_code()))
             logging.error("Error Code: " + str(error.get_error_code()))
+            raise RuntimeError('Failed to connect with Sailthru API')
 
     def upload(self, library_items, report_email=None):
         if not library_items:
@@ -80,7 +82,7 @@ class SailthruApiService(object):
                     response.json['error'],
                     response.json['errormsg']
                 )
-                return
+                raise RuntimeError('Failed to connect with Sailthru API')
 
             sailthru_content = response.json['content']
             if not sailthru_content:

--- a/edx_sailthru/sailthru_content/services/tests/test_sailthru_api_service.py
+++ b/edx_sailthru/sailthru_content/services/tests/test_sailthru_api_service.py
@@ -48,8 +48,9 @@ class SailthruApiServiceTests(unittest.TestCase):
         mock_get_result = mock.Mock(json=error_result)
         mock_get_result.is_ok.return_value = False
         mock_api_get.return_value = mock_get_result
-        sailthru_item_collection = self.sailthru_client.list()
-        self.assertEqual(len(sailthru_item_collection), 0)
+
+        with self.assertRaises(RuntimeError):
+            self.sailthru_client.list()
         self.assertTrue(mock_error_log.called)
 
     @mock.patch('sailthru.sailthru_client.SailthruClient.api_get')
@@ -126,5 +127,6 @@ class SailthruApiServiceTests(unittest.TestCase):
         post_response_mock.get_error.return_value = error_mock
         mock_api_post.return_value = post_response_mock
 
-        self.sailthru_client._upload_batch_file(self.faker.uri_path())
+        with self.assertRaises(RuntimeError):
+            self.sailthru_client._upload_batch_file(self.faker.uri_path())
         self.assertTrue(mock_error_log.called)

--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -59,9 +59,9 @@ def pull(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, skip_compilem
                     )
                 )
 
-                # Return immediately, without trying to merge the PR. We don't
+                # Fail job immediately, without trying to merge the PR. We don't
                 # want to merge PRs without compiled messages.
-                return
+                raise RuntimeError('Failed to compile messages.')
 
             repo.merge_pr()
 


### PR DESCRIPTION
This pull request is to make sure jenkins sailthru and translation jobs fail when a error occur during the job process. The only was to do that is to raise exception and break the program. 