### PR TITLE
Fail to test out a non-master branch

### DIFF
--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git fetch && git checkout efischer/reactifex && git pull'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,6 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
+        subprocess.run(['git', 'fetch'], check=True)
         subprocess.run(['git', 'reset', '--hard', '3af204a76718ca50cd22938b1c42139129a724c1'], check=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git checkout origin/efischer/reactifex'], check=True, shell=True)
+        subprocess.run(['git fetch && git checkout origin/efischer/reactifex'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -143,10 +143,12 @@ class Repo:
 
     def clone(self):
         """Clone the repo."""
+        subprocess.run(['rm', '-rf', 'studio-frontend'], check=True)
         subprocess.run(['git', 'clone', '--depth', '1', self.clone_url], check=True)
 
     def branch(self):
         """Create and check out a new branch."""
+        subprocess.run(['git', 'reset', '--hard', '3af204a76718ca50cd22938b1c42139129a724c1'], check=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -149,7 +149,7 @@ class Repo:
     def branch(self):
         """Create and check out a new branch."""
         subprocess.run(['git', 'fetch'], check=True)
-        subprocess.run(['git', 'reset', '--hard', '3af204a76718ca50cd22938b1c42139129a724c1'], check=True)
+        subprocess.run(['git', 'checkout', 'efischer/reactifex'], check=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch -v --all) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git branch -r) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git', 'fetch', ';', 'git', 'checkout', 'efischer/reactifex'], check=True)
+        subprocess.run(['git fetch && git checkout efischer/reactifex'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch -v) && (>&2 git checkout efischer/reactifex)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch -v --all) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch) && (>&2 git checkout efischer/reactifex)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch -v) && (>&2 git checkout efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['pwd && git fetch && git checkout efischer/reactifex'], check=True, shell=True, stdout=subprocess.PIPE)
+        subprocess.run(['git checkout origin/efischer/reactifex'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git branch -r) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 git remote show origin) && (>&2 git branch -a) && (>&2 git remote update) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git fetch && git checkout efischer/reactifex'], check=True, shell=True)
+        subprocess.run(['pwd && git fetch && git checkout efischer/reactifex'], check=True, shell=True, stdout=subprocess.PIPE)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git fetch && git checkout origin/efischer/reactifex'], check=True, shell=True)
+        subprocess.run(['git fetch && git checkout efischer/reactifex && git pull'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git', 'fetch', '&&', 'git', 'checkout', 'efischer/reactifex'], check=True)
+        subprocess.run(['git', 'fetch', ';', 'git', 'checkout', 'efischer/reactifex'], check=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 ls) && (>&2 git fetch) && (>&2 git checkout efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,8 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['git', 'fetch'], check=True)
-        subprocess.run(['git', 'checkout', 'efischer/reactifex'], check=True)
+        subprocess.run(['git', 'fetch', '&&', 'git', 'checkout', 'efischer/reactifex'], check=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -148,7 +148,7 @@ class Repo:
 
     def branch(self):
         """Create and check out a new branch."""
-        subprocess.run(['(>&2 pwd) && (>&2 git remote show origin) && (>&2 git branch -a) && (>&2 git remote update) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
+        subprocess.run(['(>&2 pwd) && (>&2 git remote show origin) && (>&2 git branch -a) && (>&2 git remote update) && (>&2 git config --list) && (>&2 git checkout origin/efischer/reactifex)'], check=True, shell=True)
         subprocess.run(['git', 'checkout', '-b', self.branch_name], check=True)
 
     def pull_translations(self):


### PR DESCRIPTION
For some reason, the bot can only see `master`, no matter how hard I try to get it to check out a different branch so I can test things before merging to master.

https://tools-edx-jenkins.edx.org/job/translations/job/studio-frontend-pull_translations/44/console, for the latest example.

```
22:37:54 /edx/var/jenkins/jobs/translations/jobs/studio-frontend-pull_translations/workspace/ecommerce-scripts/studio-frontend
22:37:54 * remote origin
22:37:54   Fetch URL: https://********@github.com/edx/studio-frontend.git
22:37:54   Push  URL: https://********@github.com/edx/studio-frontend.git
22:37:54   HEAD branch: master
22:37:54   Remote branch:
22:37:54     master tracked
22:37:54   Local branch configured for 'git pull':
22:37:54     master merges with remote master
22:37:54   Local ref configured for 'git push':
22:37:54     master pushes to master (up to date)
22:37:54 * master
22:37:54   remotes/origin/HEAD -> origin/master
22:37:54   remotes/origin/master
22:37:54 Fetching origin
22:37:54 core.repositoryformatversion=0
22:37:54 core.filemode=true
22:37:54 core.bare=false
22:37:54 core.logallrefupdates=true
22:37:54 remote.origin.url=https://********@github.com/edx/studio-frontend.git
22:37:54 remote.origin.fetch=+refs/heads/master:refs/remotes/origin/master
22:37:54 branch.master.remote=origin
22:37:54 branch.master.merge=refs/heads/master
22:37:54 error: pathspec 'origin/efischer/reactifex' did not match any file(s) known to git.
```