### PR TITLE
update third-party library versions

### DIFF
--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -7,5 +7,8 @@ PyGithub==1.43.3
 PyYAML==3.12
 transifex-client==0.12.4
 
-# Python libraries to be installed directly from github
-git+https://github.com/edx/django-wiki.git@v0.0.19#egg=django-wiki
+# third-party
+edx-proctoring-proctortrack==1.0.1
+
+# third-party Python libraries to be installed directly from github
+git+https://github.com/edx/django-wiki.git@v0.0.20#egg=django-wiki


### PR DESCRIPTION
These libraries must be available as the transifex push/pull jobs are
running. This syncs their used versions with the versions used on platform master.

[EDUCATOR-3913](https://openedx.atlassian.net/browse/EDUCATOR-3913)

https://github.com/edx/edx-platform/commit/287692f515b52eedb416692927861b05fda5c7a4#diff-eb7c51ab8bb879241ff7e8a2494bf0c9R142 for additional context. @nedbat there're code comments in here that indicate we need to add configs for the .po files being merged; is that necessary to get translations in this third-party library flowing properly through these jobs? 