### PR TITLE
Fix translations jobs by adding constraint.txt

### DIFF
--- a/transifex/constraints.txt
+++ b/transifex/constraints.txt
@@ -1,0 +1,2 @@
+# transifex-client 0.12.4 did not pin urllib3, but requests cannot work with urllib3 1.25.2 (https://github.com/transifex/transifex-client/blob/128b212a5f07d1a1475ebd10fda0bf6dbbe2c055/requirements.txt)
+urllib3<1.25

--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -1,3 +1,4 @@
+-c ./constraints.txt
 Django==1.11.2
 edx-i18n-tools==0.4.6
 PyGithub==1.43.3


### PR DESCRIPTION
All the translation job are failing in jenkins. 
The root cause is that, on transifex-client 1.12.4, which this is pinned, the urllib3 dependency is not pinned. See https://github.com/transifex/transifex-client/blob/128b212a5f07d1a1475ebd10fda0bf6dbbe2c055/requirements.txt
Because of it, a new urllib3 (1.25.1) was installing and both transifex and requests libraries can't support that.
The added a constraint file to pin the urllib3 be < 1.25