### PR TITLE
Set skip check changes default true for geoipupdate.

### DIFF
--- a/geoipupdate/pull.py
+++ b/geoipupdate/pull.py
@@ -74,6 +74,7 @@ def parse_arguments():
     parser.add_argument(
         '--skip-check-changes',
         action='store_true',
+        default=True,
         help='Skip the check changes step.'
     )
     return parser.parse_args()


### PR DESCRIPTION
The command was checking for translation changes, skipped the step by setting default value True.

PROD-354