### PR TITLE
update ga_homepage_report requirements

### DIFF
--- a/google_analytics/requirements.txt
+++ b/google_analytics/requirements.txt
@@ -1,3 +1,3 @@
-google-api-python-client==1.5.3
+google-api-python-client>1.6.6
 pandas==0.17.0
 XlsxWriter==0.9.3


### PR DESCRIPTION
Google is discontinuing support for JSON-RPC and Global HTTP Batch Endpoints, the docs state we should be using `google-api-python-client` > 1.6.6 to comply with their deprecation schedule

[PROD-871](https://openedx.atlassian.net/browse/PROD-871)