### PR TITLE
Adding django-statici18n support to pull translation job.

### DIFF
--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -34,6 +34,7 @@ six==1.13.0               # via edx-opaque-keys, libsass, mock, paver, python-me
 stevedore==1.31.0
 urllib3==1.25.7           # via requests
 watchdog==0.9.0
+lxml==4.5.0
 
 
 boto3==1.4.8

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -160,6 +160,13 @@ class Repo:
         """
         subprocess.run(['make', 'pull_translations'], check=True)
 
+    def compilejs_translations(self):
+        """
+        Build djangojs.js files using paver i18n_compilejs
+        command in platform
+        """
+        subprocess.run(['paver', 'i18n_compilejs'], check=True)
+
     def compilemessages(self):
         """Run the django-admin compilemessages command and return a bool indicating whether or not it succeeded. """
         # Messages may fail to compile (e.g., a translator may accidentally translate a


### PR DESCRIPTION
This patch would enable pull translation job for edx-platform
to generate aggregate JS Catalog for all apps
via django-static18n package. For now developer has to do
this process to enable js translations to be available in production.

PROD-960