### PR TITLE
Removing explicit calls to compilejs

### DIFF
--- a/transifex/pull.py
+++ b/transifex/pull.py
@@ -60,7 +60,6 @@ def pull(clone_url, repo_owner, merge_method=DEFAULT_MERGE_METHOD, skip_compilem
         logger.info('Pulling translations for [%s].', repo.name)
 
         repo.pull_translations()
-        repo.compilejs_translations()
 
         if skip_compilemessages:
             logger.info('Skipping compilemessages.')

--- a/transifex/utils.py
+++ b/transifex/utils.py
@@ -160,12 +160,6 @@ class Repo:
         """
         subprocess.run(['make', 'pull_translations'], check=True)
 
-    def compilejs_translations(self):
-        """
-        Build djangojs.js files using paver i18n_compilejs
-        command in platform
-        """
-        subprocess.run(['paver', 'i18n_compilejs'], check=True)
 
     def compilemessages(self):
         """Run the django-admin compilemessages command and return a bool indicating whether or not it succeeded. """


### PR DESCRIPTION
Compilejs is breaking on other repos
as  we expected that this script (pull.py)
only executes  for edx-platform repo.
Now moving it to edx-platform.