### PR TITLE
[BD-6] Use python 3.8 for tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "3.5"
-    - "3.6"
+    - "3.8"
 
 install:
   - pip install -r ./edx_sailthru/requirements/test.txt

--- a/geoipupdate/test/test_geoip_update.py
+++ b/geoipupdate/test/test_geoip_update.py
@@ -51,8 +51,8 @@ class GeoipTestCases(unittest.TestCase):
 
     def test_shutil_raise(self):
         out_file = tempfile.NamedTemporaryFile(delete=False)
-        existing_file_as_string = 'random'
-        self.assertRaises(shutil.Error, write(out_file, existing_file_as_string))
+        existing_file_as_string = 'invalid/path/file'
+        self.assertRaises(FileNotFoundError, write, out_file, existing_file_as_string)
 
     def test_file_content(self):
         existing_file = tempfile.NamedTemporaryFile(delete=False)

--- a/geoipupdate/test/test_geoip_update.py
+++ b/geoipupdate/test/test_geoip_update.py
@@ -49,7 +49,7 @@ class GeoipTestCases(unittest.TestCase):
 
         temp_dir.cleanup()
 
-    def test_shutil_raise(self):
+    def test_file_not_found_raise(self):
         out_file = tempfile.NamedTemporaryFile(delete=False)
         existing_file_as_string = 'invalid/path/file'
         self.assertRaises(FileNotFoundError, write, out_file, existing_file_as_string)


### PR DESCRIPTION
Run tests using python 3.8.

test_shutil_raise was modified since previous syntaxis was incorrect and the expected results never happened.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol
