### PR TITLE
update conflicting requirements

### DIFF
--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -1,6 +1,6 @@
 -c ./constraints.txt
-Django==1.11.2
-edx-i18n-tools==0.4.6
+Django==2.2.12
+edx-i18n-tools==0.5.3
 PyGithub==1.43.3
 PyYAML==3.12
 transifex-client==0.12.4

--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -1,6 +1,6 @@
 babel==2.8.0
 django==2.2.12
-edx-i18n-tools==0.4.6
+edx-i18n-tools==0.5.3
 enmerkar-underscore==1.0.0
 enmerkar==0.7.1 
 mako==1.0.7
@@ -12,7 +12,7 @@ transifex-client==0.12.4
 edx-proctoring-proctortrack==1.0.1
 
 # third-party Python libraries to be installed directly from github
-git+https://github.com/edx/django-wiki.git@v0.0.20#egg=django-wiki
+git+https://github.com/edx/django-wiki.git@0.1.1#egg=django-wiki
 
 # used by paver
 argh==0.26.2              # via watchdog


### PR DESCRIPTION
### [PROD-2238](https://openedx.atlassian.net/browse/PROD-2238) / [PROD-2239](https://openedx.atlassian.net/browse/PROD-2239)

### Description
Update Django, edx-i18n-tools, and django wiki versions to fix edx-platform push and pull translations failures under PROD-2239, which are primarily happening due to Django version conflicts. PROD-2238 is concerned with updating outdated edx-i18n-tools requirements. 

**Note: After updating the requirements, I verified their installation in Python 3.7 virtualenv. Both the changed files installed successfully.**