### PR TITLE
update pyGitHub to be py38 compatible

### DIFF
--- a/transifex/requirements.txt
+++ b/transifex/requirements.txt
@@ -1,6 +1,6 @@
 -c ./constraints.txt
 Django==2.2.12
 edx-i18n-tools==0.5.3
-PyGithub==1.43.3
+PyGithub==1.53
 PyYAML==3.12
 transifex-client==0.12.4

--- a/transifex/requirements/edx-mktg.txt
+++ b/transifex/requirements/edx-mktg.txt
@@ -1,7 +1,7 @@
 # base transifex push/pull script requirements
 Django==1.11.2
 edx-i18n-tools==0.4.5
-PyGithub==1.43.3
+PyGithub==1.53
 PyYAML==3.12
 transifex-client==0.12.4
 

--- a/transifex/requirements/edx-platform.txt
+++ b/transifex/requirements/edx-platform.txt
@@ -5,7 +5,7 @@ enmerkar-underscore==1.0.0
 enmerkar==0.7.1 
 mako==1.0.7
 markey==0.8
-PyGithub==1.43.3
+PyGithub==1.53
 transifex-client==0.12.4
 
 # third-party


### PR DESCRIPTION
### [PROD-2224](https://openedx.atlassian.net/browse/PROD-2224)

### Description

Update PyGitHub to the latest version available to work with Py3.8