### PR TITLE
feat: separate edx-proctoring translation requirements

### DIFF
--- a/transifex/requirements/edx-proctoring.txt
+++ b/transifex/requirements/edx-proctoring.txt
@@ -1,0 +1,3 @@
+-r ./edx-platform.txt
+
+django-simple-history==3.0.0


### PR DESCRIPTION
edx-proctoring needs simple history now and that causes the translation job to fail https://tools-edx-jenkins.edx.org/job/translations/job/edx-proctoring-push_translations/35/ but we'd prefer not to add simple history  to every translation job

the better long-term fix is to update the proctoring translation targets to use i18n_tools