### PR TITLE
chore: add edx-analytics-dashboard python requirements to enable translation extraction

### DIFF
--- a/transifex/requirements/edx-analytics-dashboard.txt
+++ b/transifex/requirements/edx-analytics-dashboard.txt
@@ -1,0 +1,10 @@
+-r ../requirements.txt
+
+django-countries==7.2.1
+django-soapbox==1.6.1
+django-waffle==2.2.1
+django-webpack-loader==0.7.0
+edx-auth-backends==4.0.0
+edx-django-release-util==1.1.0
+edx-drf-extensions==7.0.1
+pinax-announcements==4.0.0


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Please review

Without these requirements installed on the jenkins, the [translation push job](https://tools-edx-jenkins.edx.org/job/translations/job/edx-analytics-dashboard-push_translations/) will fail.