### PR TITLE
add edx-proctoring cryptography dependency

### DIFF
--- a/transifex/requirements/edx-proctoring.txt
+++ b/transifex/requirements/edx-proctoring.txt
@@ -1,3 +1,4 @@
 -r ./edx-platform.txt
 
+cryptography==35.0.0
 django-simple-history==3.0.0


### PR DESCRIPTION
@edx/masters-devs-cosmonauts 

It looks like this was getting installed as a dependency of something else that has recently changed. I can't seem to hunt that down but I suppose that's not terribly important, we need this as a dependency anyway.